### PR TITLE
Add mat4 x mat4 improvement to int8mm shaders

### DIFF
--- a/metal-perf/reduce_group_mat4xmat4_int8mm.metal
+++ b/metal-perf/reduce_group_mat4xmat4_int8mm.metal
@@ -1,0 +1,93 @@
+#include <metal_stdlib>
+using namespace metal;
+
+template <typename T> struct Vec4Type {};
+
+template <> struct Vec4Type<float> {
+  using type = float4;
+};
+
+template <> struct Vec4Type<half> {
+  using type = half4;
+};
+
+#if __METAL_VERSION__ >= 310
+template <> struct Vec4Type<bfloat> {
+  using type = bfloat4;
+};
+#endif
+
+template <typename T, unsigned blockSize=8>
+kernel void
+int8pack_mm(constant T *A [[buffer(0)]], constant char *B [[buffer(1)]],
+            constant T *scales [[buffer(2)]],
+            device T *outputData [[buffer(3)]],
+            constant int3 &sizes [[buffer(4)]], // M, K, N
+            uint2 group_index [[threadgroup_position_in_grid]],
+            uint2 threadgroup_index [[thread_position_in_threadgroup]]) {
+  using vecT = typename Vec4Type<T>::type;
+  const uint K = sizes.y;
+  const uint N = sizes.z;
+  int out_idx = (group_index.x * blockSize + threadgroup_index.x);
+  int n = 4 * (out_idx % (N/4));
+  int m = 4 * (out_idx / (N/4));
+  // Offset pointers
+  constant vecT *A_ptr = reinterpret_cast<constant vecT *>(A + m * K);
+  constant char4 *B_ptr = reinterpret_cast<constant char4 *>(B + n * K);
+
+  outputData += m * N;
+
+  float4x4 rc;
+  for(int j = 0; j < 4; ++j) {
+    rc[j] = float4(0.0);
+  }
+  for (unsigned k = threadgroup_index.y * 4; k < K; k += 4 * blockSize) {
+    threadgroup_barrier(mem_flags::mem_none);
+
+    float4x4 b_mat;
+    for(int j = 0; j < 4; ++j) {
+      b_mat[j] = float4(B_ptr[k / 4 + j * K / 4]);
+    }
+
+    float4x4 a_mat;
+    for(int j = 0; j < 4; ++j) {
+      a_mat[j] = float4(A_ptr[k / 4 + j * K / 4]);
+    }
+
+    rc += transpose(b_mat) * a_mat;
+  }
+
+  // Accumulate results acorss SIMD group? (8 threads using vec4)
+  threadgroup float4x4 tgp_memory[blockSize][blockSize];
+  tgp_memory[threadgroup_index.x][threadgroup_index.y] = rc;
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+  if (threadgroup_index.y == 0) {
+    for (int i = 1; i < blockSize; i++) {
+      rc += tgp_memory[threadgroup_index.x][i];
+    }
+    *reinterpret_cast<device vecT *>(outputData + n) =
+        vecT(rc[0] * float4(*reinterpret_cast<constant vecT *>(scales + n)));
+    *reinterpret_cast<device vecT *>(outputData + n + N) =
+        vecT(rc[1] * float4(*reinterpret_cast<constant vecT *>(scales + n)));
+    *reinterpret_cast<device vecT *>(outputData + n + 2 * N) =
+        vecT(rc[2] * float4(*reinterpret_cast<constant vecT *>(scales + n)));
+    *reinterpret_cast<device vecT *>(outputData + n + 3 * N) =
+        vecT(rc[3] * float4(*reinterpret_cast<constant vecT *>(scales + n)));
+  }
+}
+
+#define INSTANTIATE_INT8MM(DTYPE)                                              \
+  template [[host_name("int8pack_mm_" #DTYPE)]] kernel void                    \
+  int8pack_mm<DTYPE>(                                                          \
+      constant DTYPE * A [[buffer(0)]], constant char *B [[buffer(1)]],        \
+      constant DTYPE *scales [[buffer(2)]],                                    \
+      device DTYPE *outputData [[buffer(3)]],                                  \
+      constant int3 &sizes [[buffer(4)]],                                      \
+      uint2 group_index [[threadgroup_position_in_grid]],                      \
+      uint2 threadgroup_index [[thread_position_in_threadgroup]]);
+
+INSTANTIATE_INT8MM(half);
+INSTANTIATE_INT8MM(float);
+#if __METAL_VERSION__ >= 310
+INSTANTIATE_INT8MM(bfloat);
+#endif

--- a/metal-perf/reduce_mat4xmat4_int8mm.metal
+++ b/metal-perf/reduce_mat4xmat4_int8mm.metal
@@ -1,0 +1,69 @@
+#include <metal_stdlib>
+using namespace metal;
+
+template <typename T> struct Vec4Type {};
+
+template <> struct Vec4Type<float> {
+  using type = float4;
+};
+
+template <> struct Vec4Type<half> {
+  using type = half4;
+};
+
+#if __METAL_VERSION__ >= 310
+template <> struct Vec4Type<bfloat> {
+  using type = bfloat4;
+};
+#endif
+
+template <typename T>
+kernel void int8pack_mm(constant T *A [[buffer(0)]],
+                        constant char *B [[buffer(1)]],
+                        constant T *scales [[buffer(2)]],
+                        device T *outputData [[buffer(3)]],
+                        constant uint3 &sizes [[buffer(4)]], // M, K, N
+                        uint2 thread_index [[thread_position_in_grid]]) {
+  const uint K = sizes.y;
+  const uint N = sizes.z;
+  const uint m = thread_index.y; // 0..M/4-1
+  const uint n = thread_index.x; // 0..N/4-1
+  using vecT = typename Vec4Type<T>::type;
+  constant vecT *A_ptr = reinterpret_cast<constant vecT *>(A + m * 4 * K);
+  constant char4 *B_ptr = reinterpret_cast<constant char4 *>(B + n * 4 * K);
+
+  float4x4 rc;
+  for(int j = 0; j < 4; ++j) {
+    rc[j] = float4(0.0);
+  }
+  for (uint k = 0; k < K / 4; k++) {
+    float4x4 b_mat;
+    for(int j = 0; j < 4; ++j) {
+      b_mat[j] = float4(B_ptr[k + j * K / 4]);
+    }
+    float4x4 a_mat;
+    for(int j = 0; j < 4; ++j) {
+      a_mat[j] = float4(A_ptr[k + j * K / 4]);
+    }
+    rc += transpose(b_mat) * a_mat;
+  }
+  reinterpret_cast<device vecT*>(outputData + 4 * m * N)[n] = vecT(rc[0] * float4(reinterpret_cast<constant vecT *>(scales)[n]));
+  reinterpret_cast<device vecT*>(outputData + (4 * m + 1) * N)[n] = vecT(rc[1] * float4(reinterpret_cast<constant vecT *>(scales)[n]));
+  reinterpret_cast<device vecT*>(outputData + (4 * m + 2) * N)[n] = vecT(rc[2] * float4(reinterpret_cast<constant vecT *>(scales)[n]));
+  reinterpret_cast<device vecT*>(outputData + (4 * m + 3) * N)[n] = vecT(rc[3] * float4(reinterpret_cast<constant vecT *>(scales)[n]));
+}
+
+#define INSTANTIATE_INT8MM(DTYPE)                                              \
+  template [[host_name("int8pack_mm_" #DTYPE)]] kernel void                    \
+  int8pack_mm<DTYPE>(constant DTYPE * A [[buffer(0)]],                         \
+                     constant char *B [[buffer(1)]],                           \
+                     constant DTYPE *scales [[buffer(2)]],                     \
+                     device DTYPE *outputData [[buffer(3)]],                   \
+                     constant uint3 &sizes [[buffer(4)]],                      \
+                     uint2 thread_index [[thread_position_in_grid]])
+
+INSTANTIATE_INT8MM(half);
+INSTANTIATE_INT8MM(float);
+#if __METAL_VERSION__ >= 310
+INSTANTIATE_INT8MM(bfloat);
+#endif


### PR DESCRIPTION
This PR adds two int8mm shaders:
- reduce_mat4xmat4_int8mm
- reduce_group_mat4xmat4_int8mm

The last shader achieves a 2x perf improvement over the existing reduce_group_int8mm shader. It exploits the idea introduced in #2 that we can take advantage of matrix x matrix multiplication, instead of just matrix x vector.

Performance achieved on Apple M1 Pro:
- Perf of reduce_group_mat4xmat4_int8mm type bfloat dim 32x4128x4096 is 574.259 GFLOPs
- Perf of reduce_group_int8mm type bfloat dim 32x4128x4096 is 225.049 GFLOPs
- Perf of reduce_mat4xmat4_int8mm type bfloat dim 32x4128x4096 is 121.002 GFLOPs
- Perf of reduce_mat4_int8mm type bfloat dim 32x4128x4096 is 30.0652 GFLOPs
- Perf of reduce_vec4_int8mm type bfloat dim 32x4128x4096 is 35.5442 GFLOPs
- Perf of naive_int8mm type bfloat dim 32x4128x4096 is 9.01958 GFLOPs