### PR TITLE
Improve perf of mat4 int8 shaders using 8x8x1 threadgroup

### DIFF
--- a/metal-perf/int8mm.mm
+++ b/metal-perf/int8mm.mm
@@ -293,8 +293,12 @@ struct Int8MMMat4OpDescriptor : public Int8MMOpDescriptor {
   using Int8MMOpDescriptor::Int8MMOpDescriptor;
   void dispatchThreads(id<MTLComputeCommandEncoder> encoder,
                        unsigned maxThreadsPerGroup) const override {
+    constexpr auto blockSize = 8;
+    if (maxThreadsPerGroup < blockSize * blockSize) {
+      throw std::runtime_error("Can't dispatch!");
+    }
     [encoder dispatchThreads:MTLSizeMake(N/4, M, 1)
-        threadsPerThreadgroup:MTLSizeMake(std::min(maxThreadsPerGroup, N/4), 1, 1)];
+        threadsPerThreadgroup:MTLSizeMake(blockSize, blockSize, 1)];
   }
 };
 
@@ -302,8 +306,12 @@ struct Int8MMMat4xMat4OpDescriptor : public Int8MMOpDescriptor {
   using Int8MMOpDescriptor::Int8MMOpDescriptor;
   void dispatchThreads(id<MTLComputeCommandEncoder> encoder,
                        unsigned maxThreadsPerGroup) const override {
+    constexpr auto blockSize = 8;
+    if (maxThreadsPerGroup < blockSize * blockSize) {
+      throw std::runtime_error("Can't dispatch!");
+    }
     [encoder dispatchThreads:MTLSizeMake(N/4, M/4, 1)
-        threadsPerThreadgroup:MTLSizeMake(std::min(maxThreadsPerGroup, N/4), 1, 1)];
+        threadsPerThreadgroup:MTLSizeMake(blockSize, blockSize, 1)];
   }
 };
 


### PR DESCRIPTION
Improved perf of mat4 int8 shaders by using an 8x8x1 threadgroup:

Using device Apple M1 Pro
- Perf of reduce_group_mat4xmat4_int8mm type bfloat dim 32x4128x4096 is 569.543 GFLOPs
- Perf of reduce_mat4xmat4_int8mm type bfloat dim 32x4128x4096 is 369.181 GFLOPs
- Perf of reduce_group_int8mm type bfloat dim 32x4128x4096 is 230.136 GFLOPs
- Perf of reduce_mat4_int8mm type bfloat dim 32x4128x4096 is 150.624 GFLOPs
- Perf of reduce_vec4_int8mm type bfloat dim 32x4128x4096 is 35.5223 GFLOPs
- Perf of naive_int8mm type bfloat dim 32x4128x4096 is 9.01956 GFLOPs